### PR TITLE
Fixed problem with URLs with common root, like Youtube channels

### DIFF
--- a/elfeed-summary.el
+++ b/elfeed-summary.el
@@ -748,7 +748,7 @@ items."
                 show-read)
       (format "+%s " elfeed-summary-unread-tag))
     "="
-     (rx-to-string (elfeed-feed-url feed) t)
+     (rx-to-string (elfeed-feed-id feed) t)
     )))
 
 (defun elfeed-summary--search-feed-notify (widget &rest _)

--- a/elfeed-summary.el
+++ b/elfeed-summary.el
@@ -748,10 +748,8 @@ items."
                 show-read)
       (format "+%s " elfeed-summary-unread-tag))
     "="
-    (replace-regexp-in-string
-     (rx "?" (* not-newline) eos)
-     ""
-     (elfeed-feed-id feed)))))
+     (rx-to-string (elfeed-feed-url feed) t)
+    )))
 
 (defun elfeed-summary--search-feed-notify (widget &rest _)
   "A function to run in `:notify' in a feed widget button.


### PR DESCRIPTION
The current code trims the URL to avoid an invalid regular expression for the filter. But `rx-to-string` can generate a valid and unique one.