### PR TITLE
Renamed elfeed--shuffle to elfeed-shuffle

### DIFF
--- a/elfeed-summary.el
+++ b/elfeed-summary.el
@@ -1549,7 +1549,7 @@ of string."
                       elfeed-summary-refresh-on-each-update)
               (elfeed-summary--refresh-if-exists)))))
     (add-hook 'elfeed-update-hooks elfeed-update-closure)
-    (mapc #'elfeed-update-feed (elfeed--shuffle feeds))
+    (mapc #'elfeed-update-feed (elfeed-shuffle feeds))
     (run-hooks 'elfeed-update-init-hooks)
     (elfeed-db-save)))
 


### PR DESCRIPTION
This break was introduced in elfeed commit
28fec1deb3e833a8cd186fc1d391f7d11c352cb8. The function elfeed--shuffle was renamed to elfeed-shuffle in the elfeed package.

Fixes #17 